### PR TITLE
Fix project name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ One of the most disrupting noise inside diffs is about indentation changes. They
 
 By now this is a filter for **git diff --word-diff=porcelain** which works on **--color** or plain output, I will work to provide an ecosystem to ease it use.
 
-#Test
+# Test
 
 ```bash
-$ git clone albfan:word-diff-filter
-$ cd word-diff-filter
-$ ln -s $(pwd)/word-diff-filter.py ~/bin/word-diff-filter
+$ git clone https://github.com/albfan/filter-word-diff.git
+$ cd filter-word-diff/
+$ ln -s $(pwd)/filter-word-diff.py ~/bin/filter-word-diff
 $ cd <path-to-your-repo>
-$ git diff --word-diff=porcelain --color master feature | word-diff-filter
+$ git diff --word-diff=porcelain --color master feature | filter-word-diff
 ```
 


### PR DESCRIPTION
By the way, on my `git` installation (git version 2.27.0), the `--color-words=porcelain --color` is simply not working anymore (it colors the `@@` chunk markers, and then prints the new version of the file without any hint of what the difference with the previous version was :-( so this script can't do much with that broken input.
